### PR TITLE
disabled matrix enchanting(tetris style)

### DIFF
--- a/config/quark-common.toml
+++ b/config/quark-common.toml
@@ -1123,7 +1123,7 @@
 [oddities]
 	"Totem Of Holding" = false
 	Backpack = true
-	"Matrix Enchanting" = true
+	"Matrix Enchanting" = false
 	Pipes = true
 	Magnets = true
 


### PR DESCRIPTION
disabled matrix enchanting(tetris style) as it does not work well with packs that have tons of enchants like e5