### PR TITLE
change ignore spawn cap item

### DIFF
--- a/config/apotheosis/spawner.cfg
+++ b/config/apotheosis/spawner.cfg
@@ -11,7 +11,7 @@ general {
 
 ignore_spawn_cap {
     # The item that applies this modifier. [default: minecraft:chorus_fruit]
-    S:item=minecraft:chorus_fruit
+    S:item=minecraft:bedrock
 
     # The max value of this stat. [range: -2147483648 ~ 2147483647, default: 2147483647]
     I:max_value=2147483647


### PR DESCRIPTION
Changed the item for "ignore spawn cap" from chorus fruit to bedrock... this way creative players can still do the thing, but not normal gameplay... it is far too OP (even for apotheosis) and can bring down a server in about 0.5 seconds lol